### PR TITLE
Hub event data in single-user server.

### DIFF
--- a/jupyterhub/singleuser.py
+++ b/jupyterhub/singleuser.py
@@ -260,6 +260,10 @@ class SingleUserNotebookApp(NotebookApp):
     def _user_changed(self, change):
         self.log.name = change.new
 
+    @property
+    def event_data(self):
+        return { 'username': self.user }
+
     hub_host = Unicode().tag(config=True)
 
     hub_prefix = Unicode('/hub/').tag(config=True)


### PR DESCRIPTION
This is foreshadowing a bit. This provides a way to pass Hub data to events emitted by the single-user notebook server.